### PR TITLE
Migrate to Swift 3 + Xcode 8

### DIFF
--- a/TVPickerView.xcodeproj/project.pbxproj
+++ b/TVPickerView.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 		55621E621BD7259100D388B5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Chuquimian Productions";
 				TargetAttributes = {
 					5027B9CD1BDC72AA00D3F7FC = {
@@ -220,9 +220,11 @@
 					};
 					55621E691BD7259100D388B5 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					55621E7A1BD7259100D388B5 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 55621E691BD7259100D388B5;
 					};
 				};
@@ -331,6 +333,7 @@
 		5027B9D31BDC72AA00D3F7FC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -350,6 +353,7 @@
 		5027B9D41BDC72AA00D3F7FC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -379,8 +383,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -423,8 +429,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -441,6 +449,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -456,6 +465,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.chuquimianproductions.TVPickerView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -468,6 +478,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.chuquimianproductions.TVPickerView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -479,6 +490,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.chuquimianproductions.TVPickerViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TVPickerView.app/TVPickerView";
 			};
 			name = Debug;
@@ -491,6 +503,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.chuquimianproductions.TVPickerViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TVPickerView.app/TVPickerView";
 			};
 			name = Release;
@@ -505,6 +518,7 @@
 				5027B9D41BDC72AA00D3F7FC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		55621E651BD7259100D388B5 /* Build configuration list for PBXProject "TVPickerView" */ = {
 			isa = XCConfigurationList;

--- a/TVPickerView.xcodeproj/xcshareddata/xcschemes/TVPickerView.xcscheme
+++ b/TVPickerView.xcodeproj/xcshareddata/xcschemes/TVPickerView.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TVPickerView.xcodeproj/xcshareddata/xcschemes/TVPickerViewFramework.xcscheme
+++ b/TVPickerView.xcodeproj/xcshareddata/xcschemes/TVPickerViewFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TVPickerView/AppDelegate.swift
+++ b/TVPickerView/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/TVPickerView/Base.lproj/Main.storyboard
+++ b/TVPickerView/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -17,8 +18,6 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k6O-2j-FIe">
-                                <rect key="frame" x="724" y="81" width="472" height="86"/>
-                                <animations/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="TVPickerView Example"/>
                                 <connections>
@@ -26,27 +25,21 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nAk-Zx-U7V" customClass="TVPickerView" customModule="TVPickerView" customModuleProvider="target">
-                                <rect key="frame" x="760" y="259" width="400" height="128"/>
-                                <animations/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="Vbb-jV-ow7"/>
                                     <constraint firstAttribute="width" constant="400" id="m7C-iH-G5u"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="When the picker is in focus, click to allow content selection. You can then swipe between items, or use the arrow buttons" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E6f-yP-mcn">
-                                <rect key="frame" x="710" y="432" width="500" height="139"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="500" id="qHa-kt-9rz"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="29"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6j-yv-zrj">
-                                <rect key="frame" x="648" y="621" width="195" height="86"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="195" id="GWt-OQ-des"/>
                                     <constraint firstAttribute="height" constant="86" id="btm-nS-7wm"/>
@@ -58,8 +51,6 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IUf-xf-JnN">
-                                <rect key="frame" x="863" y="621" width="195" height="86"/>
-                                <animations/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Mid"/>
                                 <connections>
@@ -67,8 +58,6 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rwa-kW-Qlo">
-                                <rect key="frame" x="1078" y="621" width="195" height="86"/>
-                                <animations/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Last"/>
                                 <connections>
@@ -76,18 +65,14 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T0i-f5-Z9z">
-                                <rect key="frame" x="840" y="788" width="240" height="128"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waiting...." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wnL-IZ-0nI">
-                                        <rect key="frame" x="82" y="54" width="76" height="21"/>
-                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <animations/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="wnL-IZ-0nI" firstAttribute="centerY" secondItem="T0i-f5-Z9z" secondAttribute="centerY" id="WQA-Da-ChO"/>
                                     <constraint firstAttribute="height" constant="128" id="jSX-Oz-d4o"/>
@@ -96,18 +81,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G9n-PL-G9g">
-                                <rect key="frame" x="840" y="924" width="240" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current Index Color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pcq-7u-yS9">
-                                        <rect key="frame" x="45" y="14" width="150" height="21"/>
-                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" red="1" green="0.7725490196" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="1" green="0.7725490196" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <animations/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="pcq-7u-yS9" firstAttribute="centerY" secondItem="G9n-PL-G9g" secondAttribute="centerY" id="NdL-za-HhE"/>
                                     <constraint firstAttribute="width" constant="240" id="QV4-W5-3Ig"/>
@@ -116,15 +97,12 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="These buttons only work properly on a real device. Not sure why." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MD5-TW-ung">
-                                <rect key="frame" x="713" y="715" width="494" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Rwa-kW-Qlo" firstAttribute="leading" secondItem="IUf-xf-JnN" secondAttribute="trailing" constant="20" id="5t3-g6-h6o"/>
                             <constraint firstItem="IUf-xf-JnN" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="7W3-XI-KRD"/>
@@ -162,4 +140,9 @@
             <point key="canvasLocation" x="477" y="265"/>
         </scene>
     </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <nil key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation" orientation="landscapeRight"/>
+        <simulatedScreenMetrics key="destination"/>
+    </simulatedMetricsContainer>
 </document>

--- a/TVPickerView/TVPickerMover.swift
+++ b/TVPickerView/TVPickerMover.swift
@@ -8,20 +8,20 @@
 
 import UIKit
 
-typealias MoverBlock = (CGFloat -> Void)
+typealias MoverBlock = ((CGFloat) -> Void)
 
 //TODO: Curve this parabolically
 
 class TVPickerMover: NSObject {
     
-    private var timer: NSTimer?
-    private var call: MoverBlock?
-    private var completed: dispatch_block_t?
-    private var stepDistance: CGFloat = 0.0
-    private var steps = 25
-    private var count = 0
+    fileprivate var timer: Timer?
+    fileprivate var call: MoverBlock?
+    fileprivate var completed: ()->() = { }
+    fileprivate var stepDistance: CGFloat = 0.0
+    fileprivate var steps = 25
+    fileprivate var count = 0
     
-    func startGenerating(time t: NSTimeInterval, totalDistance dx: CGFloat, call: MoverBlock, completed: dispatch_block_t? = nil) {
+    func startGenerating(time t: TimeInterval, totalDistance dx: CGFloat, call: @escaping MoverBlock, completed: @escaping ()->() = { } ) {
         
         stopGenerating()
         
@@ -31,7 +31,7 @@ class TVPickerMover: NSObject {
         self.completed = completed
         let time = t / Double(steps)
         
-        self.timer = NSTimer.scheduledTimerWithTimeInterval(time, target: self, selector: "timerFired", userInfo: nil, repeats: true)
+        self.timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(TVPickerMover.timerFired), userInfo: nil, repeats: true)
     }
     
     func stopGenerating() {
@@ -47,7 +47,7 @@ class TVPickerMover: NSObject {
         
         if count >= steps {
             stopGenerating()
-            completed?()
+            completed()
         }
     }
 }

--- a/TVPickerView/TVPickerView.swift
+++ b/TVPickerView/TVPickerView.swift
@@ -11,19 +11,19 @@ import QuartzCore
 
 //MARK: TVPickerView Class
 
-@objc public class TVPickerView: UIView, TVPickerInterface {
+@objc open class TVPickerView: UIView, TVPickerInterface {
     
-    weak public var focusDelegate: TVPickerViewFocusDelegate?
-    weak public var dataSource: TVPickerViewDataSource?
-    weak public var delegate: TVPickerViewDelegate?
+    weak open var focusDelegate: TVPickerViewFocusDelegate?
+    weak open var dataSource: TVPickerViewDataSource?
+    weak open var delegate: TVPickerViewDelegate?
     
-    static private let AnimationInterval: NSTimeInterval = 0.1
-    static private let SwipeMultiplier: CGFloat = 0.5
-    static private let MaxDrawn = 4
+    static fileprivate let AnimationInterval: TimeInterval = 0.1
+    static fileprivate let SwipeMultiplier: CGFloat = 0.5
+    static fileprivate let MaxDrawn = 4
     
-    private let mover = TVPickerMover()
-    private let contentView = UIView()
-    private let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .Dark))
+    fileprivate let mover = TVPickerMover()
+    fileprivate let contentView = UIView()
+    fileprivate let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,9 +35,9 @@ import QuartzCore
         setup()
     }
     
-    private(set) public var deepFocus = false {
+    fileprivate(set) open var deepFocus = false {
         didSet {
-            UIView.animateWithDuration(TVPickerView.AnimationInterval, animations: deepFocus ? bringIntoDeepFocus : bringOutOfDeepFocus)
+            UIView.animate(withDuration: TVPickerView.AnimationInterval, animations: deepFocus ? bringIntoDeepFocus : bringOutOfDeepFocus)
             
             if deepFocus {
                 becomeFirstResponder()
@@ -48,7 +48,7 @@ import QuartzCore
         }
     }
     
-    private var currentIndex: Int = 0 {
+    fileprivate var currentIndex: Int = 0 {
         didSet {
             if currentIndex != oldValue {
                 delegate?.pickerView(self, didChangeToIndex: currentIndex)
@@ -56,20 +56,20 @@ import QuartzCore
         }
     }
     
-    public var selectedIndex: Int {
+    open var selectedIndex: Int {
         return currentIndex
     }
     
-    private var itemCount: Int = 0
-    private var indexesAndViews = [Int: UIView]()
+    fileprivate var itemCount: Int = 0
+    fileprivate var indexesAndViews = [Int: UIView]()
     
-    public func reloadData() {
+    open func reloadData() {
         
         guard let dataSource = dataSource else {
             return
         }
         
-        layoutMargins = UIEdgeInsetsZero
+        layoutMargins = UIEdgeInsets.zero
         
         itemCount = dataSource.numberOfViewsInPickerView(self)
         
@@ -83,7 +83,7 @@ import QuartzCore
         }
     }
     
-    private func loadFromIndex(index: Int) {
+    fileprivate func loadFromIndex(_ index: Int) {
         
         guard let dataSource = dataSource else {
             return
@@ -117,7 +117,7 @@ import QuartzCore
         scrollToNearestIndex(0.0)
 
         //Waiting fixes everything
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(0.1 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(0.1 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)) {
             self.internalScrollToIndex(index, animated: true, multiplier: 2.0, speed: 0.1)
         }
     }
@@ -125,20 +125,20 @@ import QuartzCore
 
 extension TVPickerView {
     
-    private func setup() {
+    fileprivate func setup() {
         
         visualEffectView.sizeToView(self)
         visualEffectView.clipsToBounds = true
         addSubview(visualEffectView)
         
         contentView.sizeToView(self)
-        contentView.backgroundColor = .clearColor()
+        contentView.backgroundColor = .clear
         addSubview(contentView)
         
-        backgroundColor = .clearColor()
+        backgroundColor = .clear
         
-        layer.shadowColor = UIColor.blackColor().CGColor
-        layer.shadowOffset = CGSizeMake(0, 10)
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 10)
         layer.cornerRadius = 7.0
         contentView.clipsToBounds = true
         contentView.layer.cornerRadius = 7.0
@@ -152,53 +152,53 @@ extension TVPickerView {
 
 extension TVPickerView {
     
-    override public func didUpdateFocusInContext(context: UIFocusUpdateContext, withAnimationCoordinator coordinator: UIFocusAnimationCoordinator) {
-        super.didUpdateFocusInContext(context, withAnimationCoordinator: coordinator)
+    override open func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
     
         if context.nextFocusedView == self {
-            UIView.animateWithDuration(TVPickerView.AnimationInterval, animations: bringIntoFocus)
+            UIView.animate(withDuration: TVPickerView.AnimationInterval, animations: bringIntoFocus)
         }
         else if context.previouslyFocusedView == self {
-            UIView.animateWithDuration(TVPickerView.AnimationInterval, animations: bringOutOfFocus)
+            UIView.animate(withDuration: TVPickerView.AnimationInterval, animations: bringOutOfFocus)
         }
     }
     
-    override public func shouldUpdateFocusInContext(context: UIFocusUpdateContext) -> Bool {
+    override open func shouldUpdateFocus(in context: UIFocusUpdateContext) -> Bool {
         return !deepFocus
     }
     
-    private func bringIntoFocus() {
+    fileprivate func bringIntoFocus() {
         layer.transform = CATransform3DMakeScale(1.2, 1.2, 1.0)
         layer.shadowRadius = 7.0
         layer.shadowOpacity = 0.2
         contentView.backgroundColor = UIColor(white: 1.0, alpha: 0.7)
     }
     
-    private func bringOutOfFocus() {
+    fileprivate func bringOutOfFocus() {
         layer.transform = CATransform3DMakeScale(1.0, 1.0, 1.0)
         layer.shadowRadius = 0.0
         layer.shadowOpacity = 0.0
-        contentView.backgroundColor = .clearColor()
+        contentView.backgroundColor = .clear
     }
     
-    private func bringIntoDeepFocus() {
+    fileprivate func bringIntoDeepFocus() {
         layer.transform = CATransform3DMakeScale(1.4, 1.4, 1.0)
         layer.shadowRadius = 15.0
         layer.shadowOpacity = 0.7
-        contentView.backgroundColor = .whiteColor()
+        contentView.backgroundColor = .white
         focusDelegate?.pickerView(self, deepFocusStateChanged: true)
     }
     
-    private func bringOutOfDeepFocus() {
+    fileprivate func bringOutOfDeepFocus() {
         bringIntoFocus()
         focusDelegate?.pickerView(self, deepFocusStateChanged: false)
     }
     
-    override public func canBecomeFocused() -> Bool {
+    override open var canBecomeFocused : Bool {
         return true
     }
     
-    override public func canBecomeFirstResponder() -> Bool {
+    override open var canBecomeFirstResponder : Bool {
         return true
     }
 }
@@ -207,8 +207,8 @@ extension TVPickerView {
 
 extension TVPickerView: UIGestureRecognizerDelegate {
     
-    override public func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        super.touchesBegan(touches, withEvent: event)
+    override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
         
         if !deepFocus {
             return
@@ -217,8 +217,8 @@ extension TVPickerView: UIGestureRecognizerDelegate {
         mover.stopGenerating()
     }
     
-    override public func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        super.touchesMoved(touches, withEvent: event)
+    override open func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
     
         if !deepFocus {
             return
@@ -228,16 +228,16 @@ extension TVPickerView: UIGestureRecognizerDelegate {
             return
         }
         
-        let lastLocation = touch.previousLocationInView(self)
-        let thisLocation = touch.locationInView(self)
+        let lastLocation = touch.previousLocation(in: self)
+        let thisLocation = touch.location(in: self)
         
         let dx = thisLocation.x - lastLocation.x
         
         iterate(dx)
     }
     
-    override public func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        super.touchesEnded(touches, withEvent: event)
+    override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
         
         if !deepFocus {
             return
@@ -246,14 +246,14 @@ extension TVPickerView: UIGestureRecognizerDelegate {
         scrollToNearestIndex(0.3)
     }
     
-    override public func pressesBegan(presses: Set<UIPress>, withEvent event: UIPressesEvent?) {
-        super.pressesBegan(presses, withEvent: event)
+    override open func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        super.pressesBegan(presses, with: event)
         
         guard let press = presses.first else {
             return
         }
         
-        if press.type == .Select {
+        if press.type == .select {
             let changedValue = !deepFocus
             
             if !changedValue {
@@ -269,9 +269,9 @@ extension TVPickerView: UIGestureRecognizerDelegate {
             
         switch press.type {
             
-        case .UpArrow, .RightArrow:
+        case .upArrow, .rightArrow:
             iterateForwards()
-        case .DownArrow, .LeftArrow:
+        case .downArrow, .leftArrow:
             iterateBackwards()
         default:
             break
@@ -283,13 +283,13 @@ extension TVPickerView: UIGestureRecognizerDelegate {
 
 extension TVPickerView {
     
-    func iterate(dx: CGFloat) {
+    func iterate(_ dx: CGFloat) {
         
         for (_, v) in indexesAndViews {
             
             let newViewX = dx * TVPickerView.SwipeMultiplier + CGFloat(v.center.x)
             
-            let containerCenter = CGPointMake(bounds.width / 2.0, bounds.height / 2.0)
+            let containerCenter = CGPoint(x: bounds.width / 2.0, y: bounds.height / 2.0)
             let vdx = min(fabs(containerCenter.x - newViewX) / containerCenter.x, 1.0)
 
             v.setX(newViewX, vdx)
@@ -316,7 +316,7 @@ extension TVPickerView {
         internalScrollToIndex(currentIndex - 1, animated: true, multiplier: 1.0, speed: 0.1)
     }
     
-    private func scrollToNearestIndex(speed: NSTimeInterval, uncancellable: Bool = false) {
+    fileprivate func scrollToNearestIndex(_ speed: TimeInterval, uncancellable: Bool = false) {
         
         let (locatedIndex, offset) = nearestViewToCenter()
  
@@ -330,10 +330,10 @@ extension TVPickerView {
         })
     }
     
-    private func nearestViewToCenter() -> (index: Int, distance: CGFloat) {
+    fileprivate func nearestViewToCenter() -> (index: Int, distance: CGFloat) {
         let targetX = bounds.width / 2.0
         var locatedIndex = 0
-        var smallestDistance = CGFloat.max
+        var smallestDistance = CGFloat.greatestFiniteMagnitude
         var offset: CGFloat = 0.0
         for (idx, v) in indexesAndViews {
             let x = v.center.x
@@ -355,12 +355,12 @@ extension TVPickerView {
         return (locatedIndex, offset)
     }
     
-    public func scrollToIndex(idx: Int) {
+    public func scrollToIndex(_ idx: Int) {
         scrollToIndex(idx, animated: true)
     }
     
     //TODO: animated doesn't work. Fix it and make it public
-    private func scrollToIndex(idx: Int, animated: Bool) {
+    fileprivate func scrollToIndex(_ idx: Int, animated: Bool) {
 
         let di = abs(idx - currentIndex)
         var a = animated
@@ -372,7 +372,7 @@ extension TVPickerView {
         internalScrollToIndex(idx, animated: a, multiplier: 2.0, speed: 0.2)
     }
     
-    private func internalScrollToIndex(idx: Int, animated: Bool, multiplier: CGFloat, speed: NSTimeInterval) {
+    fileprivate func internalScrollToIndex(_ idx: Int, animated: Bool, multiplier: CGFloat, speed: TimeInterval) {
         
         if !animated {
             loadFromIndex(idx)
@@ -387,7 +387,7 @@ extension TVPickerView {
         })
     }
     
-    private func xPositionForIndex(idx: Int) -> CGFloat {
+    fileprivate func xPositionForIndex(_ idx: Int) -> CGFloat {
         return ((CGFloat(idx) * frame.width) / CGFloat(2.0)) + frame.width / 2.0
     }
 }
@@ -396,13 +396,13 @@ extension TVPickerView {
 
 extension TVPickerView {
 
-    private func calculate() {
+    fileprivate func calculate() {
         
         guard let dataSource = dataSource else {
             return
         }
         
-        let indexesDrawn: [Int] = indexesAndViews.keys.map {$0}.sort(<)
+        let indexesDrawn: [Int] = indexesAndViews.keys.map {$0}.sorted(by: <)
         
         if indexesDrawn.count < TVPickerView.MaxDrawn {
         
@@ -417,7 +417,7 @@ extension TVPickerView {
             return
         }
         
-        guard let n = indexesDrawn.indexOf(locatedIndex) else {
+        guard let n = indexesDrawn.index(of: locatedIndex) else {
             return
         }
         
@@ -444,7 +444,7 @@ extension TVPickerView {
         }
         
         let reusingView = indexesAndViews[reuseIndex]
-        indexesAndViews.removeValueForKey(reuseIndex)
+        indexesAndViews.removeValue(forKey: reuseIndex)
         
         let newView = dataSource.pickerView(self, viewForIndex: newIndex, reusingView: reusingView)
         indexesAndViews[newIndex] = newView

--- a/TVPickerView/TVPickerViewExtensions.swift
+++ b/TVPickerView/TVPickerViewExtensions.swift
@@ -17,12 +17,12 @@ extension UIView {
     
     - returns: the receiver
     */
-    func setupForPicker(picker: TVPickerView) -> Self {
+    func setupForPicker(_ picker: TVPickerView) -> Self {
         translatesAutoresizingMaskIntoConstraints = true
-        autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
+        autoresizingMask = [.flexibleHeight, .flexibleWidth]
         
-        let size = CGSizeMake(CGRectGetWidth(picker.bounds) / 2.0, CGRectGetHeight(picker.bounds))
-        frame = CGRectMake(0, 0, size.width, size.height)
+        let size = CGSize(width: picker.bounds.width / 2.0, height: picker.bounds.height)
+        frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         
         return self
     }
@@ -33,14 +33,14 @@ extension UIView {
     - parameter x:  the actual center x position of the view
     - parameter dx: the distance from the normal position to the offset position, from 0 to 1
     */
-    func setX(x: CGFloat, _ dx: CGFloat) {
+    func setX(_ x: CGFloat, _ dx: CGFloat) {
         center.x = x
         let scaleAmount = (1 - max(dx, 0.65)) + 0.65
         layer.transform = CATransform3DMakeScale(1.0 * scaleAmount, 1.0 * scaleAmount, 1.0)
     }
 
-    func sizeToView(v: UIView) {
+    func sizeToView(_ v: UIView) {
         frame = v.bounds
-        autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
 }

--- a/TVPickerView/TVPickerViewInterfaces.swift
+++ b/TVPickerView/TVPickerViewInterfaces.swift
@@ -32,7 +32,7 @@ public protocol TVPickerInterface {
     /*!
     Scroll the picker to a particular index. **This may not work on the simulator!**
     */
-    func scrollToIndex(idx: Int)
+    func scrollToIndex(_ idx: Int)
 }
 
 public protocol TVPickerViewFocusDelegate: class {
@@ -43,7 +43,7 @@ public protocol TVPickerViewFocusDelegate: class {
     - parameter picker:      the picker
     - parameter isDeepFocus: `true` if the picker is becoming the first responder
     */
-    func pickerView(picker: TVPickerView, deepFocusStateChanged isDeepFocus: Bool)
+    func pickerView(_ picker: TVPickerView, deepFocusStateChanged isDeepFocus: Bool)
 }
 
 public protocol TVPickerViewDelegate: class {
@@ -54,7 +54,7 @@ public protocol TVPickerViewDelegate: class {
     - parameter picker: the picker
     - parameter index:  the index
     */
-    func pickerView(picker: TVPickerView, didChangeToIndex index: Int)
+    func pickerView(_ picker: TVPickerView, didChangeToIndex index: Int)
 }
 
 public protocol TVPickerViewDataSource: class {
@@ -66,7 +66,7 @@ public protocol TVPickerViewDataSource: class {
     
     - returns: the number of views in the picker (unsigned)
     */
-    func numberOfViewsInPickerView(picker: TVPickerView) -> Int
+    func numberOfViewsInPickerView(_ picker: TVPickerView) -> Int
     
     /*!
     Returns the view for a particular index in the picker
@@ -76,5 +76,5 @@ public protocol TVPickerViewDataSource: class {
     
     - returns: a view to load into the picker for the given index (unsigned)
     */
-    func pickerView(picker: TVPickerView, viewForIndex idx: Int, reusingView view: UIView?) -> UIView
+    func pickerView(_ picker: TVPickerView, viewForIndex idx: Int, reusingView view: UIView?) -> UIView
 }

--- a/TVPickerView/ViewController.swift
+++ b/TVPickerView/ViewController.swift
@@ -15,12 +15,22 @@ class ViewController: UIViewController {
     @IBOutlet weak var selectedLabel: UILabel!
     @IBOutlet weak var liveView: UIView!
 
+    fileprivate var isPickerLoaded: Bool = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         picker.focusDelegate = self
         picker.dataSource = self
         picker.delegate = self
-        picker.reloadData()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        if !isPickerLoaded {
+            picker.reloadData()
+            isPickerLoaded = true
+        }
     }
     
     let colors: [UIColor] = [

--- a/TVPickerView/ViewController.swift
+++ b/TVPickerView/ViewController.swift
@@ -24,84 +24,84 @@ class ViewController: UIViewController {
     }
     
     let colors: [UIColor] = [
-        .blackColor(),
-        .darkGrayColor(),
-        .lightGrayColor(),
-        .grayColor(),
-        .redColor(),
-        .greenColor(),
-        .blueColor(),
-        .cyanColor(),
-        .yellowColor(),
-        .magentaColor(),
-        .orangeColor(),
-        .purpleColor(),
-        .brownColor(),
-        .blackColor(),
-        .darkGrayColor(),
-        .lightGrayColor(),
-        .grayColor(),
-        .redColor(),
-        .greenColor(),
-        .blueColor(),
-        .cyanColor(),
-        .yellowColor(),
-        .magentaColor(),
-        .orangeColor(),
-        .purpleColor(),
-        .brownColor(),
-        .blackColor(),
-        .darkGrayColor(),
-        .lightGrayColor(),
-        .grayColor(),
-        .redColor(),
-        .greenColor(),
-        .blueColor(),
-        .cyanColor(),
-        .yellowColor(),
-        .magentaColor(),
-        .orangeColor(),
-        .purpleColor(),
-        .brownColor(),
-        .blackColor(),
-        .darkGrayColor(),
-        .lightGrayColor(),
-        .grayColor(),
-        .redColor(),
-        .greenColor(),
-        .blueColor(),
-        .cyanColor(),
-        .yellowColor(),
-        .magentaColor(),
-        .orangeColor(),
-        .purpleColor(),
-        .brownColor(),
+        .black,
+        .darkGray,
+        .lightGray,
+        .gray,
+        .red,
+        .green,
+        .blue,
+        .cyan,
+        .yellow,
+        .magenta,
+        .orange,
+        .purple,
+        .brown,
+        .black,
+        .darkGray,
+        .lightGray,
+        .gray,
+        .red,
+        .green,
+        .blue,
+        .cyan,
+        .yellow,
+        .magenta,
+        .orange,
+        .purple,
+        .brown,
+        .black,
+        .darkGray,
+        .lightGray,
+        .gray,
+        .red,
+        .green,
+        .blue,
+        .cyan,
+        .yellow,
+        .magenta,
+        .orange,
+        .purple,
+        .brown,
+        .black,
+        .darkGray,
+        .lightGray,
+        .gray,
+        .red,
+        .green,
+        .blue,
+        .cyan,
+        .yellow,
+        .magenta,
+        .orange,
+        .purple,
+        .brown,
     ]
 }
 
 extension ViewController {
  
     
-    @IBAction func topButtonTapped(sender: AnyObject) {
+    @IBAction func topButtonTapped(_ sender: AnyObject) {
         print("This button is here so that the picker is not in focus by default #justdemothings")
     }
     
-    @IBAction func firstButtonTapped(sender: AnyObject) {
+    @IBAction func firstButtonTapped(_ sender: AnyObject) {
         picker.scrollToIndex(0)
     }
     
-    @IBAction func midButtonTapped(sender: AnyObject) {
+    @IBAction func midButtonTapped(_ sender: AnyObject) {
         picker.scrollToIndex(colors.count / 2)
     }
     
-    @IBAction func lastButtonTapped(sender: AnyObject) {
+    @IBAction func lastButtonTapped(_ sender: AnyObject) {
         picker.scrollToIndex(colors.count - 1)
     }
 }
 
 extension ViewController: TVPickerViewFocusDelegate {
     
-    func pickerView(picker: TVPickerView, deepFocusStateChanged isDeepFocus: Bool) {
+    func pickerView(_ picker: TVPickerView, deepFocusStateChanged isDeepFocus: Bool) {
 
         if !isDeepFocus {
             selectedLabel.text = "User exited picker at index:\n\(picker.selectedIndex)"
@@ -112,19 +112,19 @@ extension ViewController: TVPickerViewFocusDelegate {
 
 extension ViewController: TVPickerViewDataSource {
    
-    func numberOfViewsInPickerView(picker: TVPickerView) -> Int {
+    func numberOfViewsInPickerView(_ picker: TVPickerView) -> Int {
         return colors.count
     }
     
-    func pickerView(picker: TVPickerView, viewForIndex idx: Int, reusingView view: UIView?) -> UIView {
+    func pickerView(_ picker: TVPickerView, viewForIndex idx: Int, reusingView view: UIView?) -> UIView {
         
         var sview = view as? UILabel
         
         if sview == nil {
             sview = UILabel()
-            sview!.textColor = .whiteColor()
-            sview!.font = .systemFontOfSize(30)
-            sview!.textAlignment = .Center
+            sview!.textColor = .white
+            sview!.font = .systemFont(ofSize: 30)
+            sview!.textAlignment = .center
         }
         
         sview!.backgroundColor = colors[idx]
@@ -135,7 +135,7 @@ extension ViewController: TVPickerViewDataSource {
 }
 
 extension ViewController: TVPickerViewDelegate {
-    func pickerView(picker: TVPickerView, didChangeToIndex index: Int) {
+    func pickerView(_ picker: TVPickerView, didChangeToIndex index: Int) {
         liveView.backgroundColor = colors[index]
     }
 }

--- a/TVPickerViewTests/TVPickerViewTests.swift
+++ b/TVPickerViewTests/TVPickerViewTests.swift
@@ -28,7 +28,7 @@ class TVPickerViewTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
This migrates the project to support Swift 3 + Xcode 8.

Worth noting is that Xcode 8's Interface Builder version triggered a project-breaking change whenever you opened a xib file. It seems the 'automatically created' diffs that IB occasionally leaves in xib files actually led to a concrete change in layout behavior. See the commit notes for ee349a2 for full details.
